### PR TITLE
Remove blank strings from authorities

### DIFF
--- a/src/main/java/com/under/demo/security/security/TokenProvider.java
+++ b/src/main/java/com/under/demo/security/security/TokenProvider.java
@@ -49,6 +49,7 @@ public class TokenProvider {
 
         Collection<? extends GrantedAuthority> authorities =
             Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .filter(authority -> !authority.isBlank())
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
Passing a blank string to `SimpleGrantedAuthority`'s constructor results in `IllegalArgumentException` being thrown.

This case happen when a user has no roles.
